### PR TITLE
Configurable timing settings

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -4,16 +4,17 @@ description: Neopixel driver
 version: 1.0
 
 config_schema:
-  - ["neopixel", "o", {title: "Settings for RGB LED handling"}]
-  - ["neopixel.timing", "o", {title: "Settings for RGB LED timing"}]
-  - ["neopixel.timing.T0H", "d", 4, {title: "Settings for 0-code HIGH level time (in 100 ns)"}]
+  - ["neopixel", "o", {title: "Settings for Neopixel handling"}]
+  - ["neopixel.timing", "o", {title: "Settings for Neopixel timing"}]
+  - ["neopixel.timing.T0H", "d", 3, {title: "Settings for 0-code HIGH level time (in 100 ns)"}]
+  - ["neopixel.timing.T0L", "d", 8, {title: "Settings for 0-code LOW level time (in 100 ns)"}]
   - ["neopixel.timing.T1H", "d", 8, {title: "Settings for 1-code HIGH level time (in 100 ns)"}]
-  - ["neopixel.timing.T0L", "d", 9, {title: "Settings for 0-code LOW level time (in 100 ns)"}]
-  - ["neopixel.timing.T1L", "d", 5, {title: "Settings for 1-code LOW level time (in 100 ns)"}]
-  - ["neopixel.timing.RES", "d", 65, {title: "Settings for reset time (in microseconds)"}]
+  - ["neopixel.timing.T1L", "d", 6, {title: "Settings for 1-code LOW level time (in 100 ns)"}]
+  - ["neopixel.timing.RES", "d", 60, {title: "Settings for reset time (in microseconds)"}]
 
 sources:
   - src
+
 includes:
   - include
 

--- a/mos.yml
+++ b/mos.yml
@@ -3,6 +3,15 @@ type: lib
 description: Neopixel driver
 version: 1.0
 
+config_schema:
+  - ["neopixel", "o", {title: "Settings for RGB LED handling"}]
+  - ["neopixel.timing", "o", {title: "Settings for RGB LED timing"}]
+  - ["neopixel.timing.T0H", "d", 4, {title: "Settings for 0-code HIGH level time (in 100 ns)"}]
+  - ["neopixel.timing.T1H", "d", 8, {title: "Settings for 1-code HIGH level time (in 100 ns)"}]
+  - ["neopixel.timing.T0L", "d", 9, {title: "Settings for 0-code LOW level time (in 100 ns)"}]
+  - ["neopixel.timing.T1L", "d", 5, {title: "Settings for 1-code LOW level time (in 100 ns)"}]
+  - ["neopixel.timing.RES", "d", 65, {title: "Settings for reset time (in microseconds)"}]
+
 sources:
   - src
 includes:

--- a/src/mgos_neopixel.c
+++ b/src/mgos_neopixel.c
@@ -40,11 +40,23 @@ struct mgos_neopixel *mgos_neopixel_create(int pin, int num_pixels,
   /* Keep in reset */
   mgos_gpio_write(pin, 0);
 
+  int T0H = mgos_sys_config_get_rgbleds_timing_T0H();
+  int T1H = mgos_sys_config_get_rgbleds_timing_T1H();
+  int T0L = mgos_sys_config_get_rgbleds_timing_T0L();
+  int T1L = mgos_sys_config_get_rgbleds_timing_T1L();
+  int RES = mgos_sys_config_get_rgbleds_timing_RES();
+
   struct mgos_neopixel *np = calloc(1, sizeof(*np));
   np->pin = pin;
   np->num_pixels = num_pixels;
   np->order = order;
   np->data = malloc(num_pixels * NUM_CHANNELS);
+  np->T0H = T0H > 0 ? T0H : 4;
+  np->T1H = T1H > 0 ? T1H : 8;
+  np->T0L = T0L > 0 ? T0L : 9;
+  np->T1L = T1L > 0 ? T1L : 5;
+  np->RES = RES > 0 ? RES : 60;
+
   mgos_neopixel_clear(np);
   return np;
 }
@@ -83,7 +95,7 @@ void mgos_neopixel_clear(struct mgos_neopixel *np) {
 void mgos_neopixel_show(struct mgos_neopixel *np) {
   mgos_gpio_write(np->pin, 0);
   mgos_usleep(60);
-  mgos_bitbang_write_bits(np->pin, MGOS_DELAY_100NSEC, 3, 8, 8, 6, np->data,
+  mgos_bitbang_write_bits(np->pin, MGOS_DELAY_100NSEC, np->T0H, np->T0L, np->T1H, np->T1L, np->data,
                           np->num_pixels * NUM_CHANNELS);
   mgos_gpio_write(np->pin, 0);
   mgos_usleep(60);

--- a/src/mgos_neopixel.c
+++ b/src/mgos_neopixel.c
@@ -24,6 +24,7 @@
 #include "mgos_bitbang.h"
 #include "mgos_gpio.h"
 #include "mgos_system.h"
+#include "mgos_config.h"
 
 #define NUM_CHANNELS 3 /* r, g, b */
 
@@ -32,6 +33,11 @@ struct mgos_neopixel {
   int num_pixels;
   enum mgos_neopixel_order order;
   uint8_t *data;
+  uint8_t T0H;
+  uint8_t T1H;
+  uint8_t T0L;
+  uint8_t T1L;
+  uint8_t RES;
 };
 
 struct mgos_neopixel *mgos_neopixel_create(int pin, int num_pixels,
@@ -40,21 +46,21 @@ struct mgos_neopixel *mgos_neopixel_create(int pin, int num_pixels,
   /* Keep in reset */
   mgos_gpio_write(pin, 0);
 
-  int T0H = mgos_sys_config_get_rgbleds_timing_T0H();
-  int T1H = mgos_sys_config_get_rgbleds_timing_T1H();
-  int T0L = mgos_sys_config_get_rgbleds_timing_T0L();
-  int T1L = mgos_sys_config_get_rgbleds_timing_T1L();
-  int RES = mgos_sys_config_get_rgbleds_timing_RES();
+  int T0H = mgos_sys_config_get_neopixel_timing_T0H();
+  int T1H = mgos_sys_config_get_neopixel_timing_T1H();
+  int T0L = mgos_sys_config_get_neopixel_timing_T0L();
+  int T1L = mgos_sys_config_get_neopixel_timing_T1L();
+  int RES = mgos_sys_config_get_neopixel_timing_RES();
 
   struct mgos_neopixel *np = calloc(1, sizeof(*np));
   np->pin = pin;
   np->num_pixels = num_pixels;
   np->order = order;
   np->data = malloc(num_pixels * NUM_CHANNELS);
-  np->T0H = T0H > 0 ? T0H : 4;
+  np->T0H = T0H > 0 ? T0H : 3;
+  np->T0L = T0L > 0 ? T0L : 8;
   np->T1H = T1H > 0 ? T1H : 8;
-  np->T0L = T0L > 0 ? T0L : 9;
-  np->T1L = T1L > 0 ? T1L : 5;
+  np->T1L = T1L > 0 ? T1L : 6;
   np->RES = RES > 0 ? RES : 60;
 
   mgos_neopixel_clear(np);


### PR DESCRIPTION
According to issue #1 I made the timing settings configurable, but had the current settings put as default. With this possibility, users may easily adjust the timing if necessary (was for me ...). Tested with C and JS example.