### PR TITLE
Updated reset timing to support latest World Semi chips

### DIFF
--- a/src/mgos_neopixel.c
+++ b/src/mgos_neopixel.c
@@ -82,13 +82,13 @@ void mgos_neopixel_clear(struct mgos_neopixel *np) {
 
 void mgos_neopixel_show(struct mgos_neopixel *np) {
   mgos_gpio_write(np->pin, 0);
-  mgos_usleep(100);
+  mgos_usleep(300);
 #if MGOS_ENABLE_BITBANG
   mgos_bitbang_write_bits(np->pin, MGOS_DELAY_100NSEC, 3, 8, 8, 3, np->data,
                           np->num_pixels * NUM_CHANNELS);
 #endif
   mgos_gpio_write(np->pin, 0);
-  mgos_usleep(100);
+  mgos_usleep(300);
   mgos_gpio_write(np->pin, 1);
 }
 


### PR DESCRIPTION
# Overview
WS made a change to the timing of its chips a little while back:
https://blog.particle.io/heads-up-ws2812b-neopixels-are-about-to-change/

# Change
Timing of the reset to be greater that 280us

# Tested
ESP32 Dev Board - GPIO2
- WS2812 neopixel strip
- WS2812E custom strip